### PR TITLE
Add  "javascript.suggest.autoImports": false

### DIFF
--- a/macos-setup.md
+++ b/macos-setup.md
@@ -139,6 +139,7 @@ In VS Code:
  "editor.codeActionsOnSave": { "source.fixAll.eslint": true },
  "editor.bracketPairColorization.enabled": true,
  "editor.guides.bracketPairs":"active",
+ "javascript.suggest.autoImports": false,
  "[javascript]": {
    "editor.formatOnSave": true,
    "editor.defaultFormatter": "esbenp.prettier-vscode"

--- a/ubuntu-setup.md
+++ b/ubuntu-setup.md
@@ -107,6 +107,7 @@ Paste these contents inside the curly brackets:
  "editor.codeActionsOnSave": { "source.fixAll.eslint": true },
  "editor.bracketPairColorization.enabled": true,
  "editor.guides.bracketPairs":"active",
+ "javascript.suggest.autoImports": false,
  "[javascript]": {
    "editor.formatOnSave": true,
    "editor.defaultFormatter": "esbenp.prettier-vscode"

--- a/windows-10-setup.md
+++ b/windows-10-setup.md
@@ -149,6 +149,7 @@ Paste these contents inside the curly brackets:
      "editor.codeActionsOnSave": { "source.fixAll.eslint": true },
      "editor.bracketPairColorization.enabled": true,
      "editor.guides.bracketPairs":"active",
+     "javascript.suggest.autoImports": false,
      "[javascript]": {
        "editor.formatOnSave": true,
        "editor.defaultFormatter": "esbenp.prettier-vscode"


### PR DESCRIPTION
When VS Code auto-inserts rubbish at the top of students' files it causes painful errors about "Webpack < 5 used to include polyfills". If students really want to use the auto-importing functionality they can enable it again for themselves. 