### PR TITLE
Add Handlebars extension

### DIFF
--- a/windows-10-setup.md
+++ b/windows-10-setup.md
@@ -108,6 +108,7 @@ Install the following VS Code extensions
 - Prettier
 - Remote - WSL
 - Live Share
+- Handlebars (the one by André Junges)
 - vscode-icons (optional, but pretty :wink:)
 - GitLens (optional)
 


### PR DESCRIPTION
Because this problem seems to have only affected Windows so far, I've only updated the Windows page of the computer-setup guide for now. If the problem sticks around maybe we should check for this extension in `@donothing/checklist` too, but that's out of my league so imma leave that for someone else to solve. 