### PR TITLE
Add config for HTML & CSS

### DIFF
--- a/macos-setup.md
+++ b/macos-setup.md
@@ -155,6 +155,14 @@ In VS Code:
     "editor.formatOnSave": true,
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
+  "[html]": {
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[css]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
   "prettier.semi": false,
   "prettier.singleQuote": true
 ```

--- a/ubuntu-setup.md
+++ b/ubuntu-setup.md
@@ -125,6 +125,14 @@ Paste this content after the first line (`{`):
     "editor.formatOnSave": true,
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
+  "[html]": {
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[css]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
   "prettier.semi": false,
   "prettier.singleQuote": true
 ```

--- a/windows-10-setup.md
+++ b/windows-10-setup.md
@@ -167,6 +167,14 @@ Paste these contents inside the curly brackets:
     "editor.formatOnSave": true,
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
+  "[html]": {
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[css]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
   "prettier.semi": false,
   "prettier.singleQuote": true
 ```


### PR DESCRIPTION
Adding in prettier config so HTML and CSS are formatting correctly from day dot. This will impact Foundations so unsure if we actually want to make this change if were still encouraging students to learn code formatting themselves. Suggesting adding it in mostly because I've been finding it difficult to mark PTBC foundations work without the linter running so I can see where code errors are. I wont be bothered in the slightest if this isn't merged. Just doing it because Gerard said I should.